### PR TITLE
Add y509 to Cyber Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Want to add your additional [bubbles](https://github.com/charmbracelet/bubbles) 
 
 - [Trufflehog](https://github.com/trufflesecurity/trufflehog) - Find leaked credentials. (_built with Bubble Tea_)
 - [WG Commander](https://github.com/AndrianBdn/wg-cmd) - A TUI for a simple WireGuard VPN setup. (_built with Bubble Tea_)
+- [y509](https://github.com/kanywst/y509) - Inspect and validate X.509 certificate chains, catching the missing intermediates and bad ordering that break curl but not browsers. (_built with Bubbles, Bubble Tea, Lip Gloss and Huh_)
 
 ### Database Tools
 


### PR DESCRIPTION
Thanks for keeping this list going.

Adding [y509](https://github.com/kanywst/y509) under Cyber Security, in alphabetical order after WG Commander.

y509 is a TUI for X.509 certificate chains. It verifies a chain against the system trust store, and separately reports how the chain was actually served: the missing intermediate, the redundant root, certificates sent out of order. That second half is the "works in the browser, breaks in curl" class of bug, since browsers chase the AIA URL to fetch a missing intermediate and curl, Go and Java do not.

**Charm libraries used:** Bubble Tea for the program loop, Bubbles for the list, viewport and help, Lip Gloss for the whole style layer including `lipgloss/table` for the chain view, and Huh for the export form. All on the v2 line.

**Completeness:** stable at v1.0.3, Apache-2.0, signed release binaries with an SBOM, and picked up into the FreeBSD ports tree as `security/y509` by a FreeBSD committer. The README opens with a VHS-recorded GIF.
